### PR TITLE
[WIP] Add resource provider path file validation

### DIFF
--- a/validator/validator.py
+++ b/validator/validator.py
@@ -14,7 +14,7 @@ import yaml
 try:
     from yaml import CLoader as yamlLoader, CDumper as yamlDumper
 except ImportError:
-    from yaml import yamlLoader, yamlDumper
+    from yaml import Loader as yamlLoader, Dumper as yamlDumper
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 


### PR DESCRIPTION
This adds validation of the resource provider path and file
- Check if file exists
- Ensure file is valid yaml or json (in case someone wants to use json I guess?)
- Ensure the object has basic fields common to all kubernetes resources (apiVersion, metadata, kind)
- If the object is a ConfigMap or a Secret, ensure it has a data field which is common to both and required

This can be expanded with more checks as we go to further make sure we catch resource files errors early