### PR TITLE
Work-around for unicode decode errors

### DIFF
--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -54,7 +54,8 @@ def bundle_resource_spec(spec):
     rel_abs_path = path[len(work_dir):]
     logging.info("Resource: {}\n".format(rel_abs_path))
 
-    content = open(path, 'r').read()
+    with open(path, 'rb') as f:
+        content = f.read().decode(errors='replace')
 
     # hash
     m = hashlib.sha256()


### PR DESCRIPTION
When running the qontract bundler I was running into this on certain files in app-interface:

```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-bundler", line 11, in <module>
    load_entry_point('qontract-validator==0.1.0', 'console_scripts', 'qontract-bundler')()
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_validator-0.1.0-py3.6.egg/validator/bundler.py", line 115, in main
    bundle['resources'] = bundle_resources(resource_dir, thread_pool_size)
  File "/usr/local/lib/python3.6/site-packages/qontract_validator-0.1.0-py3.6.egg/validator/bundler.py", line 45, in bundle_resources
    results = pool.map(bundle_resource_spec, specs)
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 266, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/usr/local/lib/python3.6/site-packages/qontract_validator-0.1.0-py3.6.egg/validator/bundler.py", line 58, in bundle_resource_spec
    content = open(path, 'r').read()
  File "/usr/lib64/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 17: invalid start byte
```

Oddly, reading the file via the python shell worked just fine. This change allowed the read continue despite the unicode errors.