### PR TITLE
Force use of LibYAML for yaml files parsing

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -11,6 +11,7 @@ RUN yum install -y epel-release && \
     yum clean all
 
 COPY validator /validator/validator
+COPY utils /validator/utils
 COPY setup.py /validator
 
 WORKDIR /validator

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -5,6 +5,7 @@ ENV LANG=en_US.utf8
 
 RUN yum install -y epel-release && \
     yum install -y python36 python36-pip && \
+    yum install -y python36-PyYAML && \
     yum clean all && \
     pip3 install --upgrade pip && \
     yum clean all

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -5,6 +5,7 @@ ENV LANG=en_US.utf8
 
 RUN yum install -y epel-release && \
     yum install -y python34 python36 && \
+    yum install -y python36-PyYAML && \
     yum clean all && \
     pip3 install --upgrade pip && \
     pip3 install tox

--- a/utils/pylibyaml.py
+++ b/utils/pylibyaml.py
@@ -1,0 +1,115 @@
+# Vendored from https://github.com/philsphicas/pylibyaml/blob/597e7856c941a64a39e9afcb7df6a069166fee47/pylibyaml/__init__.py
+
+""" Speed up PyYAML by using LibYAML bindings by default """
+
+__version__ = '0.1.0'
+
+__all__ = ['monkey_patch_pyyaml', 'restore_original_pyyaml']
+
+import importlib
+import inspect
+import sys
+import warnings
+
+# We want to insert somewhere around here. Luckily this code hasn't changed in a long time.
+# https://github.com/yaml/pyyaml/blob/538b5c93f7d5dee40322893c1e524e94a4f8bbde/lib3/yaml/__init__.py#L17
+insert_after = """
+except ImportError:
+    __with_libyaml__ = False
+"""
+
+# Insertions will be similar to the following, but may vary slightly based on PyYAML version.
+# BaseLoader = CBaseLoader
+# SafeLoader = CSafeLoader
+# FullLoader = CFullLoader
+# UnsafeLoader = CUnsafeLoader
+# Loader = CLoader
+# BaseDumper = CBaseDumper
+# SafeDumper = CSafeDumper
+# Dumper = CDumper
+insertions = None
+
+# Several functions explicitly reference loader.Loader, just as a way of avoiding conflicts with formal function
+# arguments. They really just need to refer to the module-level names.
+# add_implicit_resolver
+# https://github.com/yaml/pyyaml/blob/5.3.1/lib3/yaml/__init__.py#L317-L319
+# add_path_resolver
+# https://github.com/yaml/pyyaml/blob/5.3.1/lib3/yaml/__init__.py#L332-L334
+# add_constructor
+# https://github.com/yaml/pyyaml/blob/5.3.1/lib3/yaml/__init__.py#L346-L348
+# add_multi_constructor
+# https://github.com/yaml/pyyaml/blob/5.3.1/lib3/yaml/__init__.py#L360-L362
+replacements = {
+    "loader.Loader": "globals().Loader",
+    "loader.FullLoader": "globals().FullLoader",
+    "loader.UnsafeLoader": "globals().UnsafeLoader",
+}
+
+original_pyyaml_init_py = None
+modified_pyyaml_init_py = None
+
+def monkey_patch_pyyaml(force=False):
+    """
+    Monkey patch the pyyaml library, allowing it to use libyaml bindings
+    (CDumpers and CLoaders) by default if they are available.
+    Executes automatically on module import, if called before 'import yaml'.
+    Otherwise, needs to run with 'force=True'.
+    """
+    global insert_after
+    global insertions
+    global original_pyyaml_init_py
+    global modified_pyyaml_init_py
+
+    if 'yaml' in sys.modules and not force:
+        warnings.warn("PyYAML already loaded, refusing to patch.", ImportWarning)
+        return
+
+    try:
+        import yaml
+    except ImportError:
+        warnings.warn("PyYAML not found, nothing to do.", ImportWarning)
+        return
+
+    if not yaml.__with_libyaml__:
+        warnings.warn("LibYAML not available, nothing to do.", ImportWarning)
+        return
+
+    # Read the contents of PyYAML's __init__.py
+    try:
+        s = inspect.getsource(yaml)
+    except:
+        warnings.warn("Unable to get original source code for pyyaml __init__.py", ImportWarning)
+        return
+    else:
+        original_pyyaml_init_py = s
+
+    # Find the insertion point
+    pos = s.find(insert_after) + len(insert_after)
+    if pos == -1:
+        warnings.warn("Insertion point in __init__.py not found.", ImportWarning)
+        return
+
+    # Dynamically build the list of insertions
+    insertions = "\n" + "".join(["{} = {}\n".format(c[1:], c) for c in yaml.cyaml.__all__])
+    s = s[:pos] + insertions + s[pos:]
+    for old, new in replacements.items():
+        s = s.replace(old, new)
+
+    # Reload the modified code to update the function and class definitions
+    try:
+        exec(s, yaml.__dict__)
+    except:
+        warnings.warn("Monkey patching PyYAML failed.", ImportWarning)
+    else:
+        modified_pyyaml_init_py = s
+
+
+def restore_original_pyyaml():
+    """
+    Re-import the unmodified pyyaml library.
+    """
+    import yaml
+    importlib.reload(yaml)
+
+
+monkey_patch_pyyaml()

--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -6,6 +6,10 @@ import re
 import sys
 import logging
 
+# Monkey-patch PyYAML forcing it to use LibYAML (i.e.: CLoader, CDumper)
+# Has to load before anymarkup
+import utils.pylibyaml 
+
 import anymarkup
 import click
 import json

--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -8,7 +8,7 @@ import logging
 
 # Monkey-patch PyYAML forcing it to use LibYAML (i.e.: CLoader, CDumper)
 # Has to load before anymarkup
-import utils.pylibyaml 
+import utils.pylibyaml  # noqa: F401
 
 import anymarkup
 import click

--- a/validator/test/fixtures.py
+++ b/validator/test/fixtures.py
@@ -2,7 +2,7 @@ import os
 
 # Monkey-patch PyYAML forcing it to use LibYAML (i.e.: CLoader, CDumper)
 # Has to load before anymarkup
-import utils.pylibyaml 
+import utils.pylibyaml  # noqa: F401
 
 import anymarkup
 

--- a/validator/test/fixtures.py
+++ b/validator/test/fixtures.py
@@ -1,5 +1,9 @@
 import os
 
+# Monkey-patch PyYAML forcing it to use LibYAML (i.e.: CLoader, CDumper)
+# Has to load before anymarkup
+import utils.pylibyaml 
+
 import anymarkup
 
 

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -6,6 +6,10 @@ import sys
 from enum import Enum
 from functools import lru_cache
 
+# Monkey-patch PyYAML forcing it to use LibYAML (i.e.: CLoader, CDumper)
+# Has to load before anymarkup
+import utils.pylibyaml
+
 import anymarkup
 import click
 import jsonschema

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 
 # Monkey-patch PyYAML forcing it to use LibYAML (i.e.: CLoader, CDumper)
 # Has to load before anymarkup
-import utils.pylibyaml
+import utils.pylibyaml  # noqa: F401
 
 import anymarkup
 import click


### PR DESCRIPTION
# Context
For a long time I've been seeing qontract-validator take longer and longer to run. After digging a bit, this appears to be priparily due to the fact we're using a version of PyYAML that is not compiled with LibYAML support. Furthermore, it is not possible to tell anymarkdown to use the C-based LibYAML loaders and dumpers even if they are available.

# PyYAML
We list PyYAML as a dependency. This makes sense as it is required to run the app. However in order to ensure it is built with LibYAML support, the client also needs to have the libyaml and python development libraries in addition to having a compiler and related build tools.

In order to achieve this for our needs, I've updated the Dockerfiles to install PyYAML from the repos. Python finds the system installed package before the user-installed one (it searches /usr/lib64 before /usr/local/lib64)

# pylibyaml
I have debated between a few approaches as to how to change the code to use PyYAML with LibYAML support:
- Remove the anymarkup dependency and maintain our own json/yaml loaders (not exactly trivial)
- Use pylibyaml (https://github.com/philsphicas/pylibyaml) to monkey-patch / override PyYAML forcing it to use LibYAML
- Send a PR to anymarkup (planning to do but takes time & might not get accepted upstream)

I initially went with adding pylibyaml as a dependency but then decided to copy/vendor it into the codebase since it is small enough. I was uneasy with adding it as a dependency since that project is new, has a single author, no community, no stars, no forks and we do not know what the author will do with it in the future.

I realize this is a hack, but all things considerer this appears to be the less intrusive until (if) anymarkup supports LibYAML or we refactor the code to drop the anymarkup dependency

# Tests

The test suite is still reporting success after this change

Some rudimentary performance testing has shown the following results:
| Test   | Before   | After  | Improvement |
| -------|----------|--------|-------------|
| local  | 10s      | 1.5s    | 85%         |
| docker | 20s       | 5s      | 75%         |
| podman | 20s       | 4s      | 85%         |
