### PR TITLE
drop python34 from the test suite Dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -4,7 +4,7 @@ ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
 
 RUN yum install -y epel-release && \
-    yum install -y python34 python36 && \
+    yum install -y python36 && \
     yum clean all && \
     pip3 install --upgrade pip && \
     pip3 install tox


### PR DESCRIPTION
Python 3.4 is end-of-life and we have since moved to Python 3.6.

The tox test suite only tests against 3.6. It should be completely safe to remove 3.4 from the test suite.