### PR TITLE
Drop anymarkup dependency, use LibYAML

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -5,9 +5,9 @@ ENV LANG=en_US.utf8
 
 RUN yum install -y epel-release && \
     yum install -y python36 python36-pip && \
+    yum install -y python36-PyYAML && \
     yum clean all && \
-    pip3 install --upgrade pip && \
-    yum clean all
+    pip3 install --upgrade pip
 
 COPY validator /validator/validator
 COPY setup.py /validator

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -5,6 +5,7 @@ ENV LANG=en_US.utf8
 
 RUN yum install -y epel-release && \
     yum install -y python36 && \
+    yum install -y python36-PyYAML && \
     yum clean all && \
     pip3 install --upgrade pip && \
     pip3 install tox

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     packages=find_packages(exclude=('tests',)),
 
     install_requires=[
-        "anymarkup~=0.8",
         "Click~=7.1",
         "jsonschema~=3.2",
         "PyYAML~=5.3",

--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -6,12 +6,12 @@ import re
 import sys
 import logging
 
-import anymarkup
 import click
 import json
 
 from multiprocessing.dummy import Pool as ThreadPool
 
+from validator.utils import parse_anymarkup
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -41,7 +41,7 @@ def bundle_datafile_spec(spec):
 
     logging.info("Processing: {}\n".format(rel_abs_path))
 
-    return rel_abs_path, anymarkup.parse_file(path, force_types=None)
+    return rel_abs_path, parse_anymarkup(path)
 
 
 def bundle_resources(resource_dir, thread_pool_size):
@@ -92,7 +92,7 @@ def init_specs(work_dir):
 
 
 def bundle_graphql(graphql_schema_file):
-    return anymarkup.parse_file(graphql_schema_file, force_types=None)
+    return parse_anymarkup(graphql_schema_file)
 
 
 def fix_dir(directory):

--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -11,7 +11,7 @@ import json
 
 from multiprocessing.dummy import Pool as ThreadPool
 
-from validator.utils import parse_anymarkup
+from validator.utils import parse_anymarkup_file
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -41,7 +41,7 @@ def bundle_datafile_spec(spec):
 
     logging.info("Processing: {}\n".format(rel_abs_path))
 
-    return rel_abs_path, parse_anymarkup(path)
+    return rel_abs_path, parse_anymarkup_file(path)
 
 
 def bundle_resources(resource_dir, thread_pool_size):
@@ -92,7 +92,7 @@ def init_specs(work_dir):
 
 
 def bundle_graphql(graphql_schema_file):
-    return parse_anymarkup(graphql_schema_file)
+    return parse_anymarkup_file(graphql_schema_file)
 
 
 def fix_dir(directory):

--- a/validator/test/fixtures.py
+++ b/validator/test/fixtures.py
@@ -1,6 +1,6 @@
 import os
 
-from validator.utils import parse_anymarkup
+from validator.utils import parse_anymarkup_file
 
 
 class Fixtures(object):
@@ -20,4 +20,4 @@ class Fixtures(object):
             return f.read().strip()
 
     def get_anymarkup(self, fixture):
-        return parse_anymarkup(self.path(fixture))
+        return parse_anymarkup_file(self.path(fixture))

--- a/validator/test/fixtures.py
+++ b/validator/test/fixtures.py
@@ -1,6 +1,6 @@
 import os
 
-import anymarkup
+from validator.utils import parse_anymarkup
 
 
 class Fixtures(object):
@@ -20,4 +20,4 @@ class Fixtures(object):
             return f.read().strip()
 
     def get_anymarkup(self, fixture):
-        return anymarkup.parse(self.get(fixture), force_types=None)
+        return parse_anymarkup(self.path(fixture))

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -20,7 +20,7 @@ def parse_anymarkup(filename):
         res = _load_json(fh)
     else:
         raise NotImplementedError(
-            f'cannot load markup file with extension {file_ext}: {filename}')
+            f'markup parsing for extension {file_ext} is not implemented')
 
     return res
 

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -1,0 +1,33 @@
+import json
+import os
+import yaml
+
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader as SafeLoader
+
+
+def parse_anymarkup(filename):
+    file_ext = os.path.splitext(filename)[1][len(os.path.extsep):]
+
+    res = {}
+    if file_ext in ['yaml', 'yml']:
+        fh = open(filename, "r", encoding="utf-8")
+        res = _load_yaml(fh)
+    elif file_ext in ['json']:
+        fh = open(filename, "r", encoding="utf-8")
+        res = _load_json(fh)
+    else:
+        raise NotImplementedError(
+            f'cannot load markup file with extension {file_ext}: {filename}')
+
+    return res
+
+
+def _load_json(fh):
+    return json.load(fh)
+
+
+def _load_yaml(fh, Loader=SafeLoader):
+    return yaml.load(fh, Loader=Loader)

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -8,7 +8,10 @@ except ImportError:
     from yaml import SafeLoader as SafeLoader
 
 
-def parse_anymarkup(filename):
+def parse_anymarkup_file(filename):
+    if not os.path.isfile(filename):
+        raise FileNotFoundError(f'could not find file {filename}')
+
     file_ext = os.path.splitext(filename)[1][len(os.path.extsep):]
 
     res = {}

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -341,7 +341,7 @@ def fetch_schema(schema_url):
         r = requests.get(schema_url)
         r.raise_for_status()
         schema = r.text
-        return json.load(schema, encoding='utf-8')
+        return json.loads(schema, encoding='utf-8')
     else:
         raise MissingSchemaFile(schema_url)
 

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -6,11 +6,12 @@ import sys
 from enum import Enum
 from functools import lru_cache
 
-import anymarkup
 import click
 import jsonschema
 from jsonschema import Draft6Validator as jsonschema_validator
 import requests
+
+from validator.utils import parse_anymarkup
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -341,7 +342,7 @@ def fetch_schema(schema_url):
         r = requests.get(schema_url)
         r.raise_for_status()
         schema = r.text
-        return anymarkup.parse(schema, force_types=None)
+        return parse_anymarkup(schema)
     else:
         raise MissingSchemaFile(schema_url)
 

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -11,7 +11,6 @@ import jsonschema
 from jsonschema import Draft6Validator as jsonschema_validator
 import requests
 
-from validator.utils import parse_anymarkup
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -342,7 +341,7 @@ def fetch_schema(schema_url):
         r = requests.get(schema_url)
         r.raise_for_status()
         schema = r.text
-        return parse_anymarkup(schema)
+        return json.load(schema, encoding='utf-8')
     else:
         raise MissingSchemaFile(schema_url)
 


### PR DESCRIPTION
# Context
For a long time I've been seeing qontract-validator take longer and longer to run. After digging a bit, this appears to be priparily due to the fact we're using a version of PyYAML that is not compiled with LibYAML support. Furthermore, it is not possible to tell anymarkdown to use the C-based LibYAML loaders and dumpers even if they are available.

# PyYAML
We list PyYAML as a dependency. This makes sense as it is required to run the app. However in order to ensure it is built with LibYAML support, the client also needs to have the libyaml and python development libraries in addition to having a compiler and related build tools.

In order to achieve this for our needs, I've updated the Dockerfiles to install PyYAML from the repos. Python finds the system installed package before the user-installed one (it searches /usr/lib64 before /usr/local/lib64)

# Replacing anymarkup
The main change in this PR is dropping the anymarkup dependency in favor of our own markup parsing functions (see `parse_anymarkup`)

The initial implementation only accepts json and yaml because that is what we use right now. It should be easy to extend the functionnality to more markup languages if needed in the future.

The new functionallity will use the LibYAML `C` functions by default (`CSafeLoader`) and fall back to the native (and slower) implementation (`SafeLoader`) if LibYAML is not available.

# Tests

The test suite is still reporting success after this change.

I have also compared generated bundles from before & after these changes and the resulting bundles are identical 

Some rudimentary performance testing has shown the following results:
| Test   | Before   | After  | Improvement |
| -------|----------|--------|-------------|
| local  | 10s      | 1.5s    | 85%         |
| docker | 20s       | 5s      | 75%         |
| podman | 20s       | 4s      | 85%         |
