### PR TITLE
Remove encoding argument from JSON parsing

### DIFF
--- a/validator/validator.py
+++ b/validator/validator.py
@@ -341,7 +341,7 @@ def fetch_schema(schema_url):
         r = requests.get(schema_url)
         r.raise_for_status()
         schema = r.text
-        return json.loads(schema, encoding='utf-8')
+        return json.loads(schema)
     else:
         raise MissingSchemaFile(schema_url)
 


### PR DESCRIPTION
This argument has been deprecated since Python 3.1 and doesn't exist
in Python 3.9 anymore. Since we're using the `text` field which is
guaranteed to be an `str`, we can let `loads` handle the endocing for
us.
    
Passes pytest tests and [Jenkins run](https://ci.ext.devshift.net/job/app-sre-qontract-validator-gh-pr-check/50/).
