### PR TITLE
verify and materialize resource backrefs

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,5 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
+ENV LC_ALL=en_US.utf8
+ENV LANG=en_US.utf8
+
 RUN microdnf install \
         python3.9 && \
     microdnf clean all

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,8 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
-ENV LC_ALL=en_US.utf8
-ENV LANG=en_US.utf8
-
 RUN microdnf install \
         python3.9 && \
     microdnf clean all

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         "Click~=7.1",
         "jsonschema~=3.2",
         "PyYAML~=5.3",
-        "requests~=2.24"
+        "requests~=2.24",
+        "jsonpath-ng~=1.5",
     ],
 
     test_suite="tests",

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,6 @@ deps =
 [testenv:flake8]
 commands = flake8 validator
 deps = flake8~=3.8
+
+[flake8]
+max-line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ commands = flake8 validator
 deps = flake8~=3.8
 
 [flake8]
-max-line-length = 120
+max-line-length = 88

--- a/validator/bundle.py
+++ b/validator/bundle.py
@@ -11,9 +11,7 @@ class GraphqlType:
     bundle: "Bundle"
 
     def __post_init__(self):
-        self.fields_by_name = {
-            f.get("name"): f for f in self.spec.get("fields")
-        }
+        self.fields_by_name = {f.get("name"): f for f in self.spec.get("fields")}
 
     def get_referenced_field_type(self, name: str) -> Optional["GraphqlType"]:
         field = self.fields_by_name.get(name)
@@ -26,7 +24,9 @@ class GraphqlType:
         return self.spec.get("interfaceResolve", {}).get("field")
 
     def get_sub_type(self, discriminator: str) -> Optional["GraphqlType"]:
-        sub_type_name = self.spec.get("interfaceResolve", {}).get("fieldMap", {}).get(discriminator)
+        sub_type_name = (
+            self.spec.get("interfaceResolve", {}).get("fieldMap", {}).get(discriminator)
+        )
         if sub_type_name:
             return self.bundle.get_graphql_type_by_name(sub_type_name)
         else:
@@ -47,7 +47,9 @@ class Bundle:
     _graphql_type_by_name: dict[str, GraphqlType] = field(init=False)
 
     def __post_init__(self):
-        self._graphql_type_by_name = {t["name"]: GraphqlType(t["name"], t, self) for t in self.graphql}
+        self._graphql_type_by_name = {
+            t["name"]: GraphqlType(t["name"], t, self) for t in self.graphql
+        }
         self._top_level_schemas = {
             f.get("datafileSchema"): self._graphql_type_by_name[f["type"]]
             for f in self._graphql_type_by_name["Query"].spec["fields"]
@@ -61,20 +63,20 @@ class Bundle:
             "schemas": self.schemas,
             "graphql": self.graphql,
             "data": self.data,
-            "resources": self.resources
+            "resources": self.resources,
         }
 
-    def get_graphql_type_for_schema(self, schema) -> Optional[GraphqlType]:
+    def get_graphql_type_for_schema(self, schema: str) -> Optional[GraphqlType]:
         return self._top_level_schemas.get(schema)
 
     def get_graphql_type_by_name(self, type: str) -> Optional[GraphqlType]:
         return self._graphql_type_by_name.get(type)
 
-    def is_top_level_schema(self, datafile_schema) -> bool:
+    def is_top_level_schema(self, datafile_schema: str) -> bool:
         return datafile_schema in self._top_level_schemas
 
 
-def load_bundle(bundle_source) -> Bundle:
+def load_bundle(bundle_source: str) -> Bundle:
     bundle_data = json.load(bundle_source)
     return Bundle(
         data=bundle_data["data"],

--- a/validator/bundle.py
+++ b/validator/bundle.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass, field
+import json
+from typing import Any, Optional
+
+
+@dataclass
+class GraphqlType:
+
+    type: str
+    spec: dict[str, Any]
+    bundle: "Bundle"
+
+    def __post_init__(self):
+        self.fields_by_name = {
+            f.get("name"): f for f in self.spec.get("fields")
+        }
+
+    def get_referenced_field_type(self, name: str) -> Optional["GraphqlType"]:
+        field = self.fields_by_name.get(name)
+        if field:
+            return self.bundle.get_graphql_type_by_name(field.get("type"))
+        else:
+            return None
+
+    def get_interface_resolver_field(self) -> Optional[str]:
+        return self.spec.get("interfaceResolve", {}).get("field")
+
+    def get_sub_type(self, discriminator: str) -> Optional["GraphqlType"]:
+        sub_type_name = self.spec.get("interfaceResolve", {}).get("fieldMap", {}).get(discriminator)
+        if sub_type_name:
+            return self.bundle.get_graphql_type_by_name(sub_type_name)
+        else:
+            return None
+
+
+@dataclass
+class Bundle:
+
+    graphql: list[dict[str, Any]]
+    data: dict[str, dict[str, Any]]
+    schemas: dict[str, dict[str, Any]]
+    resources: dict[str, dict[str, Any]]
+    git_commit: str
+    git_commit_timestamp: str
+
+    _top_level_schemas: dict[str, GraphqlType] = field(init=False)
+    _graphql_type_by_name: dict[str, GraphqlType] = field(init=False)
+
+    def __post_init__(self):
+        self._graphql_type_by_name = {t["name"]: GraphqlType(t["name"], t, self) for t in self.graphql}
+        self._top_level_schemas = {
+            f.get("datafileSchema"): self._graphql_type_by_name[f["type"]]
+            for f in self._graphql_type_by_name["Query"].spec["fields"]
+            if f.get("datafileSchema")
+        }
+
+    def to_dict(self):
+        return {
+            "git_commit": self.git_commit,
+            "git_commit_timestamp": self.git_commit_timestamp,
+            "schemas": self.schemas,
+            "graphql": self.graphql,
+            "data": self.data,
+            "resources": self.resources
+        }
+
+    def get_graphql_type_for_schema(self, schema) -> Optional[GraphqlType]:
+        return self._top_level_schemas.get(schema)
+
+    def get_graphql_type_by_name(self, type: str) -> Optional[GraphqlType]:
+        return self._graphql_type_by_name.get(type)
+
+    def is_top_level_schema(self, datafile_schema) -> bool:
+        return datafile_schema in self._top_level_schemas
+
+
+def load_bundle(bundle_source) -> Bundle:
+    bundle_data = json.load(bundle_source)
+    return Bundle(
+        data=bundle_data["data"],
+        graphql=bundle_data["graphql"],
+        schemas=bundle_data["schemas"],
+        resources=bundle_data["resources"],
+        git_commit=bundle_data["git_commit"],
+        git_commit_timestamp=bundle_data["git_commit_timestamp"],
+    )

--- a/validator/resourceref.py
+++ b/validator/resourceref.py
@@ -136,7 +136,7 @@ def _find_resource_field_paths(
                         )
                     if not sub_schema_object:
                         continue
-                    for sub_schema_discriminator in  sub_schema_object["properties"][interfaceResolverField]["enum"]:
+                    for sub_schema_discriminator in sub_schema_object["properties"][interfaceResolverField]["enum"]:
                         property_graphql_sub_type = property_graphql_type.get_sub_type(
                             sub_schema_discriminator
                         )

--- a/validator/resourceref.py
+++ b/validator/resourceref.py
@@ -136,22 +136,20 @@ def _find_resource_field_paths(
                         )
                     if not sub_schema_object:
                         continue
-                    sub_schema_discriminator = sub_schema_object["properties"][
-                        interfaceResolverField
-                    ]["enum"][0]
-                    property_graphql_sub_type = property_graphql_type.get_sub_type(
-                        sub_schema_discriminator
-                    )
-                    sub_schema_paths = _find_resource_field_paths(
-                        property_schema_name,
-                        sub_schema_object,
-                        property_graphql_sub_type,
-                        ctx,
-                    )
-                    for p in sub_schema_paths:
-                        paths.append(
-                            f"{property_name}[?(@.{interfaceResolverField}=='{sub_schema_discriminator}')].{p}"
+                    for sub_schema_discriminator in  sub_schema_object["properties"][interfaceResolverField]["enum"]:
+                        property_graphql_sub_type = property_graphql_type.get_sub_type(
+                            sub_schema_discriminator
                         )
+                        sub_schema_paths = _find_resource_field_paths(
+                            property_schema_name,
+                            sub_schema_object,
+                            property_graphql_sub_type,
+                            ctx,
+                        )
+                        for p in sub_schema_paths:
+                            paths.append(
+                                f"{property_name}[?(@.{interfaceResolverField}=='{sub_schema_discriminator}')].{p}"
+                            )
             else:
                 if not ctx.bundle.is_top_level_schema(property_schema_name):
                     with ctx.step_into(datafile_schema):

--- a/validator/resourceref.py
+++ b/validator/resourceref.py
@@ -34,7 +34,7 @@ def resolve_resource_references(bundle: Bundle):
     # build up a list of resource references on a type level
     context = Context(bundle)
 
-    # find all paths to resource fields in the schemas
+    # find all jsonpath to resource reference fields in the schemas
     datafile_schema_resource_ref_jsonpaths: dict[str, list] = {}
     for datafile_schema, schema_object in bundle.schemas.items():
         if bundle.is_top_level_schema(datafile_schema):
@@ -46,7 +46,7 @@ def resolve_resource_references(bundle: Bundle):
                 parse(p) for p in paths
             ]
 
-    # use the paths for find actual resources and backref them to their data files
+    # use the jsonpaths to find actual resources and backref them to their data files
     for df_path, df in bundle.data.items():
         df_schema = df["$schema"]
         for jsonpath in datafile_schema_resource_ref_jsonpaths.get(df_schema, []):
@@ -136,7 +136,9 @@ def _find_resource_field_paths(
                         )
                     if not sub_schema_object:
                         continue
-                    for sub_schema_discriminator in sub_schema_object["properties"][interfaceResolverField]["enum"]:
+                    for sub_schema_discriminator in sub_schema_object["properties"][
+                        interfaceResolverField
+                    ]["enum"]:
                         property_graphql_sub_type = property_graphql_type.get_sub_type(
                             sub_schema_discriminator
                         )
@@ -148,7 +150,9 @@ def _find_resource_field_paths(
                         )
                         for p in sub_schema_paths:
                             paths.append(
-                                f"{property_name}[?(@.{interfaceResolverField}=='{sub_schema_discriminator}')].{p}"
+                                f"{property_name}[?(@.{interfaceResolverField}"
+                                f"=="
+                                f"'{sub_schema_discriminator}')].{p}"
                             )
             else:
                 if not ctx.bundle.is_top_level_schema(property_schema_name):

--- a/validator/resourceref.py
+++ b/validator/resourceref.py
@@ -1,0 +1,206 @@
+import sys
+from contextlib import contextmanager
+from typing import Any, Optional, Tuple
+from jsonpath_ng.ext import parse
+
+from validator.bundle import Bundle, GraphqlType
+
+
+RESOURCE_REF = "/common-1.json#/definitions/resourceref"
+CROSS_REF = "/common-1.json#/definitions/crossref"
+
+
+class SchemaTraversalLoopException(Exception):
+    pass
+
+
+class Context:
+    def __init__(self, bundle: Bundle):
+        self.bundle = bundle
+        self.datafile_schema_resource_ref_paths: dict[str, list[str]] = {}
+        self.schema_path: list[str] = []
+
+    @contextmanager
+    def step_into(self, datafile_schema: str):
+        try:
+            self.schema_path.append(datafile_schema)
+            yield
+        finally:
+            self.schema_path.pop()
+
+
+def resolve_resource_references(bundle: Bundle):
+
+    # build up a list of resource references on a type level
+    context = Context(bundle)
+
+    # find all paths to resource fields in the schemas
+    datafile_schema_resource_ref_jsonpaths: dict[str, list] = {}
+    for datafile_schema, schema_object in bundle.schemas.items():
+        if bundle.is_top_level_schema(datafile_schema):
+            graphql_type = bundle.get_graphql_type_for_schema(datafile_schema)
+            paths = process_data_file_schema_object(
+                datafile_schema, schema_object, graphql_type, context
+            )
+            datafile_schema_resource_ref_jsonpaths[datafile_schema] = [
+                parse(p) for p in paths
+            ]
+
+    # use the paths for find actual resources and backref them to their data files
+    for df_path, df in bundle.data.items():
+        df_schema = df["$schema"]
+        for jsonpath in datafile_schema_resource_ref_jsonpaths.get(df_schema, []):
+            for resource_usage in jsonpath.find(df):
+                resource = bundle.resources.get(resource_usage.value)
+                if resource:
+                    resource["backrefs"].append(
+                        {
+                            "path": df_path,
+                            "datafileSchema": df_schema,
+                            "type": bundle.get_graphql_type_for_schema(df_schema).type,
+                            "jsonpath": str(resource_usage.full_path),
+                        }
+                    )
+                else:
+                    print(f"resource {resource_usage.value} not found", file=sys.stderr)
+                    exit(1)
+
+
+def process_data_file_schema_object(
+    datafile_schema: str,
+    schema_object: dict[str, Any],
+    graphql_type: GraphqlType,
+    ctx: Context,
+) -> list[str]:
+    if datafile_schema in ctx.datafile_schema_resource_ref_paths:
+        # shortcut if result has been calculated already
+        return ctx.datafile_schema_resource_ref_paths[datafile_schema]
+    elif datafile_schema in ctx.schema_path:
+        # loop prevention
+        return []
+    else:
+        paths = _find_resource_field_paths(
+            datafile_schema, schema_object, graphql_type, ctx
+        )
+        # fill result cache
+        ctx.datafile_schema_resource_ref_paths[datafile_schema] = paths
+        return paths
+
+
+def _find_resource_field_paths(
+    datafile_schema: str,
+    schema_object: dict[str, Any],
+    graphql_type: GraphqlType,
+    ctx: Context,
+) -> list[str]:
+    """
+    inspecting a property of a datafile schema (and corresponding graphql type) to
+    find all paths to resourcerefs
+
+    * the trivial case is the property being a `resourceref` itself
+    * if the property is a simple nested structure, we call this function again with the
+      nested structure to recursively find all `resourcerefs` that might be inside
+    * if the property can be of multiple types defined by jsonschemas `oneOf`, each
+      subtype is inspected individually. in this case the corresponding graphql type
+      is required to learn about the field name and type used to distinguish types
+      from each other (e.g. `provider`). this information is then used to build
+      proper jsonpaths to the respective `resourceref` fields
+    """
+    paths = []
+    for property_name, property in schema_object.get("properties", {}).items():
+        (
+            is_array,
+            property_schema_name,
+            property_schema_object,
+        ) = _resolve_property_schema(property, ctx.bundle.schemas)
+        if property_schema_name == RESOURCE_REF:
+            # todo check if this can be in a list too?
+            paths.append(property_name)
+        elif property_schema_object:
+            property_graphql_type = (
+                graphql_type.get_referenced_field_type(property_name)
+                if graphql_type
+                else None
+            )
+            interfaceResolverField = (
+                property_graphql_type.get_interface_resolver_field()
+                if property_graphql_type
+                else None
+            )
+            if interfaceResolverField and "oneOf" in property_schema_object:
+                for sub_schema_object in property_schema_object.get("oneOf"):
+                    if "properties" not in sub_schema_object:
+                        # sub type is a ref - resolve it
+                        _, _, sub_schema_object = _resolve_property_schema(
+                            sub_schema_object, ctx.bundle.schemas
+                        )
+                    if not sub_schema_object:
+                        continue
+                    sub_schema_discriminator = sub_schema_object["properties"][
+                        interfaceResolverField
+                    ]["enum"][0]
+                    property_graphql_sub_type = property_graphql_type.get_sub_type(
+                        sub_schema_discriminator
+                    )
+                    sub_schema_paths = _find_resource_field_paths(
+                        property_schema_name,
+                        sub_schema_object,
+                        property_graphql_sub_type,
+                        ctx,
+                    )
+                    for p in sub_schema_paths:
+                        paths.append(
+                            f"{property_name}[?(@.{interfaceResolverField}=='{sub_schema_discriminator}')].{p}"
+                        )
+            else:
+                if not ctx.bundle.is_top_level_schema(property_schema_name):
+                    with ctx.step_into(datafile_schema):
+                        property_graphql_type = (
+                            graphql_type.get_referenced_field_type(property_name)
+                            if graphql_type
+                            else None
+                        )
+                        for p in process_data_file_schema_object(
+                            property_schema_name,
+                            property_schema_object,
+                            property_graphql_type,
+                            ctx,
+                        ):
+                            if is_array:
+                                paths.append(f"{property_name}[*].{p}")
+                            else:
+                                paths.append(f"{property_name}.{p}")
+    return paths
+
+
+def _resolve_property_schema(
+    property, schemas
+) -> Tuple[bool, Optional[str], Optional[dict]]:
+    """
+    this is a helper function to get the schema definition of a property, transparently
+    dealing with refs and schema refs.
+    """
+    type = property.get("type")
+    if type == "array":
+        _, datafile_type, schema_object = _resolve_property_schema(
+            property.get("items"), schemas
+        )
+        return True, datafile_type, schema_object
+    elif type == "object":
+        return False, None, property
+    else:
+        ref = property.get("$ref")
+        schema_ref = property.get("$schemaRef")
+        if schema_ref:
+            if isinstance(schema_ref, str) and schema_ref in schemas:
+                return False, schema_ref, schemas[schema_ref]
+            elif isinstance(schema_ref, dict):
+                return (
+                    False,
+                    schema_ref["properties"].get("$schema", {}).get("enum")[0],
+                    schema_ref,
+                )
+        if ref:
+            return False, ref, schemas.get(ref)
+        else:
+            return False, None, None

--- a/validator/test/fixtures/backref/bundle.yml
+++ b/validator/test/fixtures/backref/bundle.yml
@@ -1,0 +1,224 @@
+schemas:
+  "schema-1.yml":
+    properties:
+      simple_field:
+        type: string
+      simple_ref:
+        "$ref": "/common-1.json#/definitions/resourceref"
+      simple_object:
+        type: object
+        properties:
+          simple_nested_field:
+            type: string
+          simple_nested_ref:
+            "$ref": "/common-1.json#/definitions/resourceref"
+      schema_ref_field:
+        "$ref": "embedded-schema-1.yml"
+      array_field_to_nested_refs:
+        type: array
+        items:
+          type: object
+          properties:
+            simple_field:
+              type: string
+            simple_nested_ref:
+              "$ref": "/common-1.json#/definitions/resourceref"
+      one_of_ref_array:
+        type: array
+        items:
+          "$ref": "one-of-type-1.yml"
+      cross_ref_field_to_top_level_type:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "another-schema-1.yml"
+
+  "embedded-schema-1.yml":
+    properties:
+      simple_field:
+        type: string
+      simple_ref:
+        "$ref": "/common-1.json#/definitions/resourceref"
+      simple_object:
+        type: object
+        properties:
+          simple_nested_field:
+            type: string
+          simple_nested_ref:
+            "$ref": "/common-1.json#/definitions/resourceref"
+
+  "another-schema-1.yml":
+    properties:
+      simple_field:
+        type: string
+      simple_ref:
+        "$ref": "/common-1.json#/definitions/resourceref"
+      simple_object:
+        type: object
+        properties:
+          simple_nested_field:
+            type: string
+          simple_nested_ref:
+            "$ref": "/common-1.json#/definitions/resourceref"
+      schema_loop_field:
+        "$ref": "/common-1.json#/definitions/crossref"
+        "$schemaRef": "schema-1.yml"
+
+  "one-of-type-1.yml":
+    properties:
+      type_field:
+        type: string
+    oneOf:
+    - properties:
+        type_field:
+          type:
+            string
+          enum:
+          - flavour-1
+        a_field:
+          "$ref": "/common-1.json#/definitions/resourceref"
+    - properties:
+        type_field:
+          type:
+            string
+          enum:
+          - flavour-2
+        a_field:
+          type: string
+
+graphql:
+- name: Schema_v1
+  fields:
+  - name: simple_field
+    type: string
+  - name: simple_ref
+    type: string
+    isResourceRef: true
+  - name: simple_object
+    type: SimpleObject_v1
+  - name: schema_ref_field
+    type: EmbeddedSchema_v1
+  - name: array_field_to_nested_refs
+    type: EmbeddedSchema_v1
+    isList: true
+  - name: cross_ref_field_to_top_level_type
+    type: AnotherSchema_v1
+  - name: one_of_ref_array
+    type: OneOfType_v1
+    isList: true
+
+- name: SimpleObject_v1
+  fields:
+  - name: simple_nested_field
+    type: string
+  - name: simple_nested_ref
+    type: string
+    isResourceRef: true
+
+- name: EmbeddedSchema_v1
+  fields:
+  - name: simple_field
+    type: string
+  - name: simple_ref
+    type: string
+    isResourceRef: true
+  - name: simple_object
+    type: SimpleObject_v1
+
+- name: AnotherSchema_v1
+  fields:
+  - name: simple_field
+    type: string
+  - name: simple_ref
+    type: string
+    isResourceRef: true
+  - name: simple_object
+    type: SimpleObject_v1
+  - name: schema_loop_field
+    type: Schema_v1
+
+- name: OneOfType_v1
+  isInterface: true
+  interfaceResolve:
+    strategy: fieldMap
+    field: type_field
+    fieldMap:
+      flavour-1: SubType_v1
+      flavour-2: SubType_v2
+  fields:
+  - name: type_field
+    type: string
+
+- name: SubType_v1
+  interface: OneOfType_v1
+  fields:
+  - name: a_field
+    type: string
+    isResourceRef: true
+
+- name: SubType_v2
+  interface: OneOfType_v1
+  fields:
+  - name: a_field
+    type: string
+
+- name: Query
+  fields:
+  - type: Schema_v1
+    datafileSchema: "schema-1.yml"
+  - type: AnotherSchema_v1
+    datafileSchema: "another-schema-1.yml"
+
+data:
+  file-1-schema-1.yml:
+    $schema: schema-1.yml
+    simple_field: bla
+    simple_ref: /resource-1.yml
+    simple_object:
+      simple_nested_field: bla
+      simple_nested_ref: /resource-1.yml
+    schema_ref_field:
+      simple_field: bla
+      simple_ref: /resource-2.yml
+      simple_object:
+        simple_nested_field: bla
+        simple_nested_ref: /resource-2.yml
+    array_field_to_nested_refs:
+    - simple_field: bla
+      simple_nested_ref: /resource-3.yml
+    - simple_field: bla
+      simple_nested_ref: /resource-3.yml
+    cross_ref_field_to_top_level_type:
+      $ref: file-2-another-schema-1.yml
+    one_of_ref_array:
+    - $schema: one-of-type-1.yml
+      type_field: flavour-1
+      a_field: /resource-4.yml
+    - $schema: one-of-type-1.yml
+      type_field: flavour-2
+      a_field: bla
+    - $schema: one-of-type-1.yml
+      type_field: flavour-1
+      a_field: /resource-4.yml
+
+  file-2-another-schema-1.yml:
+    $schema: another-schema-1.yml
+    simple_field: bla
+    simple_ref: /resource-5.yml
+    simple_object:
+      simple_nested_field: bla
+      simple_nested_ref: /resource-5.yml
+    schema_loop_field:
+      $ref: file-1-schema-1.yml
+
+resources:
+  /resource-1.yml:
+    backrefs: []
+  /resource-2.yml:
+    backrefs: []
+  /resource-3.yml:
+    backrefs: []
+  /resource-4.yml:
+    backrefs: []
+  /resource-5.yml:
+    backrefs: []
+  /resource-6.yml:
+    backrefs: []

--- a/validator/test/test_resourceref.py
+++ b/validator/test/test_resourceref.py
@@ -1,0 +1,126 @@
+from validator.bundle import Bundle
+from validator.resourceref import resolve_resource_references
+from validator.test.fixtures import Fixtures
+
+import pytest
+
+
+@pytest.fixture
+def bundle() -> Bundle:
+    fxt = Fixtures("backref")
+    fixture = fxt.get_anymarkup(fxt.path("bundle.yml"))
+    return Bundle(
+        git_commit="c",
+        git_commit_timestamp="t",
+        schemas=fixture["schemas"],
+        graphql=fixture["graphql"],
+        data=fixture["data"],
+        resources=fixture["resources"],
+    )
+
+
+def test_simple_refs(bundle: Bundle):
+    resolve_resource_references(bundle)
+    expected = [
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "simple_ref",
+        },
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "simple_object.simple_nested_ref",
+        },
+    ]
+    assert expected == bundle.resources.get("/resource-1.yml").get("backrefs")
+
+
+def test_array_field_to_nested_refs(bundle: Bundle):
+    resolve_resource_references(bundle)
+    expected = [
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "array_field_to_nested_refs.[0].simple_nested_ref",
+        },
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "array_field_to_nested_refs.[1].simple_nested_ref",
+        },
+    ]
+    assert expected == bundle.resources.get("/resource-3.yml").get("backrefs")
+
+
+def test_embedded_schemas(bundle):
+    """
+    shows that resourceref detection works for embedded types ($ref)
+    """
+    resolve_resource_references(bundle)
+
+    expected = [
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "schema_ref_field.simple_ref",
+        },
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "schema_ref_field.simple_object.simple_nested_ref",
+        },
+    ]
+    assert expected == bundle.resources.get("/resource-2.yml").get("backrefs")
+
+
+def test_one_of_refs(bundle: Bundle):
+    """
+    this test shows that refs can be found in subtypes while the same
+    field name can be a ref in one subtype but not in another
+    """
+    resolve_resource_references(bundle)
+    expected = [
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "one_of_ref_array.[0].a_field",
+        },
+        {
+            "path": "file-1-schema-1.yml",
+            "datafileSchema": "schema-1.yml",
+            "type": "Schema_v1",
+            "jsonpath": "one_of_ref_array.[2].a_field",
+        },
+    ]
+    assert expected == bundle.resources.get("/resource-4.yml").get("backrefs")
+
+
+def test_circular_ref_top_level_type(bundle: Bundle):
+    """
+    shows that reference loops are dealth with an reference detection
+    stops looking in other top level types
+    """
+    resolve_resource_references(bundle)
+    expected = [
+        {
+            "path": "file-2-another-schema-1.yml",
+            "datafileSchema": "another-schema-1.yml",
+            "type": "AnotherSchema_v1",
+            "jsonpath": "simple_ref",
+        },
+        {
+            "path": "file-2-another-schema-1.yml",
+            "datafileSchema": "another-schema-1.yml",
+            "type": "AnotherSchema_v1",
+            "jsonpath": "simple_object.simple_nested_ref",
+        },
+    ]
+    assert expected == bundle.resources.get("/resource-5.yml").get("backrefs")


### PR DESCRIPTION
data file fields that are tagged to be references to resources by `/common-1.json#/definitions/resourceref` get their reference verified. those data files are also back referenced from the resources themselves. the bundle representation of a reference will look like this

```json
{
    ...
    "resources": {
        "/path/to/resource": {
            "content": "...",
            ...
            "backrefs": [
                {
                    "path": "/path/to/datafile.yml",
                    "datafileSchema": "/openshift/namespace-1.yml",
                    "type": "Namespace_v1",
                    "jsonpath": "jsonpath to element that references a resource"
                },
            ]
        }
    }
    ...
}
```

Depends on https://github.com/app-sre/qontract-schemas/pull/160

References:

* design doc https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/qontract-schema-resource-references.md
* https://issues.redhat.com/browse/APPSRE-5629

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>