### PR TITLE
validate oneOf array schema references

### DIFF
--- a/validator/test/fixtures/get_schema_info_from_pointer/complex.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/complex.yml
@@ -1,6 +1,9 @@
 magic: &magic
   magic_object: is_here
 
+result:
+- *magic
+
 schema:
   type: object
   properties:

--- a/validator/test/fixtures/get_schema_info_from_pointer/external_ref.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/external_ref.yml
@@ -1,6 +1,9 @@
 magic: &magic
   magic_object: is_here
 
+result:
+- *magic
+
 schemas_bundle:
   external_schema:
       type: object

--- a/validator/test/fixtures/get_schema_info_from_pointer/object.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/object.yml
@@ -1,6 +1,9 @@
 magic: &magic
   magic_object: is_here
 
+result:
+- *magic
+
 schema:
   type: object
   properties:

--- a/validator/test/fixtures/get_schema_info_from_pointer/object_array.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/object_array.yml
@@ -1,6 +1,9 @@
 magic: &magic
   magic_object: is_here
 
+result:
+- *magic
+
 schema:
   type: object
   properties:

--- a/validator/test/fixtures/get_schema_info_from_pointer/object_object.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/object_object.yml
@@ -1,6 +1,9 @@
 magic: &magic
   magic_object: is_here
 
+result:
+- *magic
+
 schema:
   type: object
   properties:

--- a/validator/test/fixtures/get_schema_info_from_pointer/one_of.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/one_of.yml
@@ -1,0 +1,26 @@
+magic: &magic
+  magic_object: is_here
+
+result:
+- *magic
+
+schemas_bundle:
+  external_schema_1:
+    type: object
+    properties:
+      mirror:
+        <<: *magic
+  external_schema_2:
+    type: string
+
+schema:
+  type: object
+  properties:
+    internal:
+      type: array
+      items:
+        oneOf:
+          - $ref: external_schema_1
+          - $ref: external_schema_2
+
+ptr: /internal/1/mirror

--- a/validator/test/fixtures/get_schema_info_from_pointer/one_of_multiple.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/one_of_multiple.yml
@@ -1,0 +1,33 @@
+magic_1: &magic_1
+  magic_object: is_here
+
+magic_2: &magic_2
+  another_magic_object: is_here
+
+result:
+- *magic_1
+- *magic_2
+
+schemas_bundle:
+  external_schema_1:
+    type: object
+    properties:
+      mirror:
+        <<: *magic_1
+  external_schema_2:
+    type: object
+    properties:
+      mirror:
+        <<: *magic_2
+
+schema:
+  type: object
+  properties:
+    internal:
+      type: array
+      items:
+        oneOf:
+          - $ref: external_schema_1
+          - $ref: external_schema_2
+
+ptr: /internal/1/mirror

--- a/validator/test/test_validator.py
+++ b/validator/test/test_validator.py
@@ -12,7 +12,7 @@ class TestGetSchemaInfoFromPointer(object):
             fixture['schema'], fixture['ptr'],
             fixture.get('schemas_bundle', {}))
 
-        assert fixture['magic'] == obj
+        assert fixture['result'] == obj
 
     def test_object(self):
         self.do_fxt_test('object.yml')
@@ -28,3 +28,9 @@ class TestGetSchemaInfoFromPointer(object):
 
     def test_external_ref(self):
         self.do_fxt_test('external_ref.yml')
+
+    def test_one_of(self):
+        self.do_fxt_test('one_of.yml')
+
+    def test_one_of_multiple(self):
+        self.do_fxt_test('one_of_multiple.yml')

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -14,8 +14,6 @@ import requests
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
-basestring = str
-
 
 class IncorrectSchema(Exception):
     def __init__(self, got, expecting):
@@ -317,7 +315,7 @@ def validate_ref(schemas_bundle, bundle, filename, data, ptr, ref):
         expected_schema = schema_info.get('$schemaRef')
 
         if expected_schema is not None:
-            if isinstance(expected_schema, basestring):
+            if isinstance(expected_schema, str):
                 if expected_schema != ref_data['$schema']:
                     errors.append(
                         ValidationError(
@@ -392,7 +390,7 @@ def find_refs(obj, ptr=None, refs=None):
 def flatten_list(collection):
     result = []
     for el in collection:
-        if hasattr(el, "__iter__") and not isinstance(el, basestring):
+        if hasattr(el, "__iter__") and not isinstance(el, str):
             result.extend(flatten_list(el))
         else:
             result.append(el)

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -14,10 +14,7 @@ import requests
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
-try:
-    basestring
-except NameError:
-    basestring = str
+basestring = str
 
 
 class IncorrectSchema(Exception):
@@ -302,37 +299,60 @@ def validate_ref(schemas_bundle, bundle, filename, data, ptr, ref):
         )
 
     try:
-        schema_info = get_schema_info_from_pointer(schema, ptr, schemas_bundle)
+        schema_infos = get_schema_info_from_pointer(
+            schema, ptr, schemas_bundle
+        )
     except KeyError as e:
         return ValidationError(
             kind,
             filename,
             "SCHEMA_DEFINITION_NOT_FOUND",
             e,
-            ref=ref['$ref']
+            ref=ref['$ref'],
+            ptr=ptr
         )
 
-    expected_schema = schema_info.get('$schemaRef')
+    errors = []
+    for schema_info in schema_infos:
+        expected_schema = schema_info.get('$schemaRef')
 
-    if expected_schema is not None:
-        if isinstance(expected_schema, basestring):
-            if expected_schema != ref_data['$schema']:
-                return ValidationError(
-                    kind,
-                    filename,
-                    "INCORRECT_SCHEMA",
-                    IncorrectSchema(ref_data['$schema'], expected_schema),
-                    ref=ref['$ref']
-                )
-        else:
-            try:
-                validator = jsonschema_validator(expected_schema)
-                validator.validate(ref_data)
-            except jsonschema.exceptions.ValidationError as e:
-                return ValidationError(kind, filename,
-                                       "SCHEMA_REF_VALIDATION_ERROR", e)
+        if expected_schema is not None:
+            if isinstance(expected_schema, basestring):
+                if expected_schema != ref_data['$schema']:
+                    errors.append(
+                        ValidationError(
+                            kind,
+                            filename,
+                            "INCORRECT_SCHEMA",
+                            IncorrectSchema(
+                                ref_data['$schema'],
+                                expected_schema
+                            ),
+                            ref=ref['$ref']
+                        )
+                    )
+                else:
+                    return ValidationRefOK(
+                        kind, filename, ref['$ref'], data['$schema']
+                    )
+            else:
+                try:
+                    validator = jsonschema_validator(expected_schema)
+                    validator.validate(ref_data)
+                    return ValidationRefOK(
+                        kind, filename, ref['$ref'], data['$schema']
+                    )
+                except jsonschema.exceptions.ValidationError as e:
+                    errors.append(
+                        ValidationError(
+                            kind,
+                            filename,
+                            "SCHEMA_REF_VALIDATION_ERROR",
+                            e
+                        )
+                    )
 
-    return ValidationRefOK(kind, filename, ref['$ref'], data['$schema'])
+    return errors
 
 
 @lru_cache()
@@ -369,20 +389,55 @@ def find_refs(obj, ptr=None, refs=None):
     return refs
 
 
-def get_schema_info_from_pointer(schema, ptr, schemas_bundle):
+def flatten_list(collection):
+    result = []
+    for el in collection:
+        if hasattr(el, "__iter__") and not isinstance(el, basestring):
+            result.extend(flatten_list(el))
+        else:
+            result.append(el)
+    return result
+
+
+def get_schema_info_from_pointer(schema, ptr, schemas_bundle) -> list[dict]:
     info = schema
 
-    for chunk in ptr.split("/")[1:]:
+    ptr_chunks = ptr.split("/")[1:]
+    for idx, chunk in enumerate(ptr_chunks):
         if chunk.isdigit():
             info = info['items']
             if list(info.keys()) == ['$ref']:
                 # this points to an external schema
                 # we need to load it
                 info = schemas_bundle[info['$ref']]
+            elif list(info.keys()) == ['oneOf']:
+                schemas = []
+                # this is a list of type options in an array
+                # we look at all of them and try to find at least one where the
+                # ptr resolves successfully
+                for ref in info["oneOf"]:
+                    try:
+                        schemas.extend(
+                            get_schema_info_from_pointer(
+                                schemas_bundle[ref["$ref"]],
+                                f"/{'/'.join(ptr_chunks[idx+1:])}",
+                                schemas_bundle
+                            )
+                        )
+                    except KeyError:
+                        pass
+                        # this subtype is not the one we are looking for
+                if not schemas:
+                    raise KeyError(
+                        f"unable to resolve schema for {ptr} "
+                        f"in oneOf options {info['oneOf']}"
+                    )
+                else:
+                    return schemas
         else:
             info = info['properties'][chunk]
 
-    return info
+    return [info]
 
 
 @click.command()
@@ -419,10 +474,17 @@ def main(only_errors, bundle):
 
     # validate refs
     results_refs = [
-        validate_ref(schemas_bundle, data_bundle,
-                     filename, data, ptr, ref).dump()
-        for filename, data in data_bundle.items()
-        for ptr, ref in find_refs(data)
+        r.dump() for r in
+        # validate_ref can return multiple errors, so we flatten the results
+        flatten_list(
+            [
+                validate_ref(
+                    schemas_bundle, data_bundle, filename, data, ptr, ref
+                )
+                for filename, data in data_bundle.items()
+                for ptr, ref in find_refs(data)
+            ]
+        )
     ]
 
     # Calculate errors


### PR DESCRIPTION
this change introduces support for `oneOf` type declarations in arrays during reference validation.
the `get_schema_info_from_pointer` function was changed to resolve a reference path (ptr) in all type options in an `oneOf` array. this might yield multiple schemas, therefore the result of `get_schema_info_from_pointer` is a list of schemas and `validate_ref` processes all of them to verify the `ptr` points to an expected schema.

```yaml
---
"$schema": /metaschema-1.json
version: '1.0'
type: object

additionalProperties: false
properties:
  ...
  resources:
    type: array
    items:
      oneOf:
      - "$ref": "/aws/terraform-resource-2.yml"
      - "$ref": "/gcp/terraform-resource-1.yml"
```

Enables `external-resources-1.yml` validation of `resources` refs in `qontract-schema`, see https://github.com/app-sre/qontract-schemas/pull/165

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>