### PR TITLE
rename isResourceRef to isResource

### DIFF
--- a/validator/test/fixtures/backref/bundle.yml
+++ b/validator/test/fixtures/backref/bundle.yml
@@ -91,7 +91,7 @@ graphql:
     type: string
   - name: simple_ref
     type: string
-    isResourceRef: true
+    isResource: true
   - name: simple_object
     type: SimpleObject_v1
   - name: schema_ref_field
@@ -111,7 +111,7 @@ graphql:
     type: string
   - name: simple_nested_ref
     type: string
-    isResourceRef: true
+    isResource: true
 
 - name: EmbeddedSchema_v1
   fields:
@@ -119,7 +119,7 @@ graphql:
     type: string
   - name: simple_ref
     type: string
-    isResourceRef: true
+    isResource: true
   - name: simple_object
     type: SimpleObject_v1
 
@@ -129,7 +129,7 @@ graphql:
     type: string
   - name: simple_ref
     type: string
-    isResourceRef: true
+    isResource: true
   - name: simple_object
     type: SimpleObject_v1
   - name: schema_loop_field
@@ -152,7 +152,7 @@ graphql:
   fields:
   - name: a_field
     type: string
-    isResourceRef: true
+    isResource: true
 
 - name: SubType_v2
   interface: OneOfType_v1


### PR DESCRIPTION
the distinction if a field is a reference to a resource or a resource can be determined by the type of the field, e.g. type Resource_v1 -> reference, type string -> resource reference

part of https://issues.redhat.com/browse/APPSRE-5950

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>