### PR TITLE
[validator] support schemaRef in oneOf

### DIFF
--- a/validator/validator.py
+++ b/validator/validator.py
@@ -429,6 +429,10 @@ def get_schema_info_from_pointer(schema, ptr, schemas_bundle) -> list[dict]:
                     except KeyError:
                         pass
                         # this subtype is not the one we are looking for
+                    try:
+                        schemas.append(schemas_bundle[ref["$schemaRef"]])
+                    except KeyError:
+                        pass
                 if not schemas:
                     raise KeyError(
                         f"unable to resolve schema for {ptr} "


### PR DESCRIPTION
this very small PR opens a very big door.

with this change, we will be able to specify that a field can either have a section inline within the same file, or have a ref to another file that has the same section.

this means that app-interface turns to be much more flexible, and we will be able to be much more flexible in file structures, without loosing schema validation and/or referencing.

for example, this PR will enable something like: https://github.com/app-sre/qontract-schemas/pull/200