### PR TITLE
enforce isContextUnique flag on gql type declarations

### DIFF
--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -13,7 +13,7 @@ from multiprocessing.dummy import Pool as ThreadPool
 from validator.bundle import Bundle
 
 from validator.utils import parse_anymarkup_file
-from validator.resourceref import resolve_resource_references
+from validator.postprocess import postprocess_bundle
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
@@ -130,6 +130,6 @@ def main(resolve, thread_pool_size,
         resources=bundle_resources(resource_dir, thread_pool_size)
     )
 
-    resolve_resource_references(bundle)
+    postprocess_bundle(bundle)
 
     sys.stdout.write(json.dumps(bundle.to_dict(), indent=4) + "\n")

--- a/validator/postprocess.py
+++ b/validator/postprocess.py
@@ -1,7 +1,9 @@
+import collections
 import sys
 from contextlib import contextmanager
 from typing import Any, Optional, Tuple
 from jsonpath_ng.ext import parse
+import hashlib
 
 from validator.bundle import Bundle, GraphqlType
 
@@ -18,6 +20,7 @@ class Context:
     def __init__(self, bundle: Bundle):
         self.bundle = bundle
         self.datafile_schema_resource_ref_paths: dict[str, list[str]] = {}
+        self.datafile_object_identifier_paths: dict = {}
         self.schema_path: list[str] = []
 
     @contextmanager
@@ -29,26 +32,81 @@ class Context:
             self.schema_path.pop()
 
 
-def resolve_resource_references(bundle: Bundle):
+def itemgetter(properties, obj):
+    def to_hashable(field):
+        if isinstance(field, collections.Hashable):
+            return field
+        else:
+            return repr(field)
+    if len(properties) == 1:
+        item = properties[0]
+        return to_hashable(obj.get(item))
+    else:
+        id = tuple(to_hashable(obj.get(item)) for item in properties)
+        if set(id) == {None}:
+            return None
+        else:
+            return id
+
+
+def ensure_context_uniqueness(df, df_path: str, config: list):
+    for jsonpath, (identifier, sub_paths) in config:
+        ids_in_context = set()
+        for object in jsonpath.find(df):
+            object_context_id = itemgetter(identifier, object.value)
+            if object_context_id is None:
+                continue
+            if object_context_id in ids_in_context:
+                print(
+                    f"{df_path} - {str(jsonpath)} - "
+                    f"the context identifier {identifier} = {object_context_id} "
+                    "is not unique within this context"
+                )
+                exit(1)
+            else:
+                ids_in_context.add(object_context_id)
+                hash_id = hashlib.md5()
+                for i in object_context_id:
+                    hash_id.update(str(i).encode())
+                object.value["__identifier"] = hash_id.hexdigest()
+            if sub_paths:
+                ensure_context_uniqueness(
+                    object.value,
+                    df_path,
+                    sub_paths
+                )
+
+
+def postprocess_bundle(bundle: Bundle):
 
     # build up a list of resource references on a type level
     context = Context(bundle)
 
     # find all jsonpath to resource reference fields in the schemas
     datafile_schema_resource_ref_jsonpaths: dict[str, list] = {}
+    datafile_schema_object_identifier_jsonpaths: dict[str, dict] = {}
     for datafile_schema, schema_object in bundle.schemas.items():
         if bundle.is_top_level_schema(datafile_schema):
             graphql_type = bundle.get_graphql_type_for_schema(datafile_schema)
-            paths = process_data_file_schema_object(
+            paths, object_identifier, _ = process_data_file_schema_object(
                 datafile_schema, schema_object, graphql_type, context
             )
             datafile_schema_resource_ref_jsonpaths[datafile_schema] = [
                 parse(p) for p in paths
             ]
+            datafile_schema_object_identifier_jsonpaths[datafile_schema] = [
+                (parse(path), properties)
+                for path, properties in object_identifier.items()
+            ]
 
     # use the jsonpaths to find actual resources and backref them to their data files
     for df_path, df in bundle.data.items():
         df_schema = df["$schema"]
+        ensure_context_uniqueness(
+            df,
+            df_path,
+            datafile_schema_object_identifier_jsonpaths.get(df_schema, [])
+        )
         for jsonpath in datafile_schema_resource_ref_jsonpaths.get(df_schema, []):
             for resource_usage in jsonpath.find(df):
                 resource = bundle.resources.get(resource_usage.value)
@@ -74,17 +132,23 @@ def process_data_file_schema_object(
 ) -> list[str]:
     if datafile_schema in ctx.datafile_schema_resource_ref_paths:
         # shortcut if result has been calculated already
-        return ctx.datafile_schema_resource_ref_paths[datafile_schema]
+        return (
+            ctx.datafile_schema_resource_ref_paths[datafile_schema],
+            ctx.datafile_object_identifier_paths[datafile_schema],
+            []
+        )
     elif datafile_schema in ctx.schema_path:
         # loop prevention
-        return []
+        return [], {}, []
     else:
-        paths = _find_resource_field_paths(
-            datafile_schema, schema_object, graphql_type, ctx
-        )
+        resource_ref_paths, object_identifiers, unique_identifiers = \
+            _find_resource_field_paths(
+                datafile_schema, schema_object, graphql_type, ctx
+            )
         # fill result cache
-        ctx.datafile_schema_resource_ref_paths[datafile_schema] = paths
-        return paths
+        ctx.datafile_schema_resource_ref_paths[datafile_schema] = resource_ref_paths
+        ctx.datafile_object_identifier_paths[datafile_schema] = dict(object_identifiers)
+        return resource_ref_paths, object_identifiers, unique_identifiers
 
 
 def _find_resource_field_paths(
@@ -106,16 +170,26 @@ def _find_resource_field_paths(
       from each other (e.g. `provider`). this information is then used to build
       proper jsonpaths to the respective `resourceref` fields
     """
-    paths = []
+    resource_paths = []
+    object_identifier_paths = {}
+    unique_properties = []
     for property_name, property in schema_object.get("properties", {}).items():
         (
             is_array,
             property_schema_name,
             property_schema_object,
         ) = _resolve_property_schema(property, ctx.bundle.schemas)
+        property_gql_field = \
+            graphql_type.fields_by_name.get(property_name, {}) \
+            if graphql_type else {}
+        if (
+            property_gql_field.get("isContextUnique", False) or
+            property_gql_field.get("isUnique", False)
+        ):
+            unique_properties.append(property_name)
         if property_schema_name == RESOURCE_REF:
             # todo check if this can be in a list too?
-            paths.append(property_name)
+            resource_paths.append(property_name)
         elif property_schema_object:
             property_graphql_type = (
                 graphql_type.get_referenced_field_type(property_name)
@@ -142,18 +216,39 @@ def _find_resource_field_paths(
                         property_graphql_sub_type = property_graphql_type.get_sub_type(
                             sub_schema_discriminator
                         )
-                        sub_schema_paths = _find_resource_field_paths(
-                            property_schema_name,
-                            sub_schema_object,
-                            property_graphql_sub_type,
-                            ctx,
-                        )
-                        for p in sub_schema_paths:
-                            paths.append(
+                        (
+                            sub_schema_resource_paths,
+                            sub_object_identifiers,
+                            sub_unique_properties
+                         ) = \
+                            _find_resource_field_paths(
+                                property_schema_name,
+                                sub_schema_object,
+                                property_graphql_sub_type,
+                                ctx,
+                            )
+                        for p in sub_schema_resource_paths:
+                            resource_paths.append(
                                 f"{property_name}[?(@.{interfaceResolverField}"
                                 f"=="
                                 f"'{sub_schema_discriminator}')].{p}"
                             )
+                        if sub_unique_properties:
+                            object_identifier_paths[
+                                f"{property_name}[?(@.{interfaceResolverField}"
+                                f"=="
+                                f"'{sub_schema_discriminator}')]"
+                            ] = (
+                                sub_unique_properties,
+                                [
+                                    (parse(path), properties)
+                                    for path, properties
+                                    in sub_object_identifiers.items()
+                                ]
+                            )
+                            property_schema_object["properties"]["__identifier"] = {
+                                "type": "string"
+                            }
             else:
                 if not ctx.bundle.is_top_level_schema(property_schema_name):
                     with ctx.step_into(datafile_schema):
@@ -162,17 +257,44 @@ def _find_resource_field_paths(
                             if graphql_type
                             else None
                         )
-                        for p in process_data_file_schema_object(
+                        if property_schema_name:
+                            resolver_func = process_data_file_schema_object
+                        else:
+                            resolver_func = _find_resource_field_paths
+                        (
+                            property_resource_paths,
+                            property_object_identifiers,
+                            property_unique_properties
+                        ) = resolver_func(
                             property_schema_name,
                             property_schema_object,
                             property_graphql_type,
                             ctx,
-                        ):
-                            if is_array:
-                                paths.append(f"{property_name}[*].{p}")
-                            else:
-                                paths.append(f"{property_name}.{p}")
-    return paths
+                        )
+                        property_name_jsonpath = property_name
+                        if is_array:
+                            property_name_jsonpath = f"{property_name}[*]"
+                        for p in property_resource_paths:
+                            resource_paths.append(f"{property_name_jsonpath}.{p}")
+                        if property_unique_properties:
+                            object_identifier_paths[
+                                property_name_jsonpath
+                            ] = (
+                                property_unique_properties,
+                                [
+                                    (parse(path), properties)
+                                    for path, properties
+                                    in property_object_identifiers.items()
+                                ]
+                            )
+                            property_schema_object["properties"]["__identifier"] = {
+                                "type": "string"
+                            }
+    if unique_properties:
+        schema_object["properties"]["__identifier"] = {
+            "type": "string"
+        }
+    return resource_paths, object_identifier_paths, unique_properties
 
 
 def _resolve_property_schema(
@@ -190,6 +312,15 @@ def _resolve_property_schema(
         return True, datafile_type, schema_object
     elif type == "object":
         return False, None, property
+    elif "oneOf" in property:
+        for variant in property.get("oneOf", []):
+            array, schema_ref, schema = _resolve_property_schema(
+                variant, schemas
+            )
+            if schema_ref or schema:
+                return array, schema_ref, schema
+        else:
+            return False, None, None
     else:
         ref = property.get("$ref")
         schema_ref = property.get("$schemaRef")

--- a/validator/test/test_resourceref.py
+++ b/validator/test/test_resourceref.py
@@ -1,5 +1,5 @@
 from validator.bundle import Bundle
-from validator.resourceref import resolve_resource_references
+from validator.postprocess import postprocess_bundle
 from validator.test.fixtures import Fixtures
 
 import pytest
@@ -20,7 +20,7 @@ def bundle(request) -> Bundle:
 
 
 def test_simple_refs(bundle: Bundle):
-    resolve_resource_references(bundle)
+    postprocess_bundle(bundle)
     expected = [
         {
             "path": "file-1-schema-1.yml",
@@ -39,7 +39,7 @@ def test_simple_refs(bundle: Bundle):
 
 
 def test_array_field_to_nested_refs(bundle: Bundle):
-    resolve_resource_references(bundle)
+    postprocess_bundle(bundle)
     expected = [
         {
             "path": "file-1-schema-1.yml",
@@ -61,7 +61,7 @@ def test_embedded_schemas(bundle):
     """
     shows that resourceref detection works for embedded types ($ref)
     """
-    resolve_resource_references(bundle)
+    postprocess_bundle(bundle)
 
     expected = [
         {
@@ -85,7 +85,7 @@ def test_one_of_refs(bundle: Bundle):
     this test shows that refs can be found in subtypes while the same
     field name can be a ref in one subtype but not in another
     """
-    resolve_resource_references(bundle)
+    postprocess_bundle(bundle)
     expected = [
         {
             "path": "file-1-schema-1.yml",
@@ -108,7 +108,7 @@ def test_circular_ref_top_level_type(bundle: Bundle):
     shows that reference loops are dealth with an reference detection
     stops looking in other top level types
     """
-    resolve_resource_references(bundle)
+    postprocess_bundle(bundle)
     expected = [
         {
             "path": "file-2-another-schema-1.yml",


### PR DESCRIPTION
implementation idea: all fields of an object which have the `isContextUnique` or `isUnique` flag set in their gql type, are hashed into an identity value and stored as an additional property `__identity` on the object itself so it can be used when the bundle is analyzed for differences in the context of the app-interface granular permission model.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>