### PR TITLE
reduce bundle size by not pretty printing it

### DIFF
--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -132,4 +132,4 @@ def main(resolve, thread_pool_size,
 
     postprocess_bundle(bundle)
 
-    sys.stdout.write(json.dumps(bundle.to_dict(), indent=4) + "\n")
+    sys.stdout.write(json.dumps(bundle.to_dict()) + "\n")


### PR DESCRIPTION
the bundle size can be reduced by 25% if we are not prettifying it on disk.
this has positive impact on bundle reload times in qontract-server.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>