### PR TITLE
APPSRE-7134: Further reduce the JSON bundle file size

### DIFF
--- a/validator/bundler.py
+++ b/validator/bundler.py
@@ -156,4 +156,4 @@ def main(
 
     postprocess_bundle(bundle, checksum_field_name=CHECKSUM_SCHEMA_FIELD)
 
-    sys.stdout.write(json.dumps(bundle.to_dict()) + "\n")
+    sys.stdout.write(json.dumps(bundle.to_dict(), separators=(",", ":")) + "\n")


### PR DESCRIPTION
This change builds atop prior changes in the Pull Request https://github.com/app-sre/qontract-validator/pull/46, where the bundle file can be optimised further, where as much as an additional 2% more can be shed from the final file size - the reduction will be between 0.5 MiB or several orders of magnitude fewer whitespaces than currently.

Related: [APPSRE-7134](https://issues.redhat.com/browse/APPSRE-7134)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>