### PR TITLE
Allow external refs as object attributes

### DIFF
--- a/validator/test/fixtures/get_schema_info_from_pointer/external_ref_obj.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/external_ref_obj.yml
@@ -1,0 +1,23 @@
+magic: &magic
+  magic_object: is_here
+
+result:
+- *magic
+
+schemas_bundle:
+  external_schema:
+      type: object
+      properties:
+        mirror:
+          <<: *magic
+
+schema:
+  type: object
+  properties:
+    internal:
+      type: object
+      properties:
+        ext:
+          $ref: external_schema
+
+ptr: /internal/ext/mirror

--- a/validator/test/fixtures/get_schema_info_from_pointer/external_ref_obj_oneof.yml
+++ b/validator/test/fixtures/get_schema_info_from_pointer/external_ref_obj_oneof.yml
@@ -1,0 +1,34 @@
+magic_1: &magic_1
+  magic_object: is_here
+
+magic_2: &magic_2
+  another_magic_object: is_here
+
+result:
+- *magic_1
+- *magic_2
+
+schemas_bundle:
+  external_schema_1:
+    type: object
+    properties:
+      ext:
+        <<: *magic_1
+  external_schema_2:
+    type: object
+    properties:
+      ext:
+        <<: *magic_2
+
+schema:
+  type: object
+  properties:
+    internal:
+      type: object
+      properties:
+        mirror:
+          oneOf:
+            - $ref: external_schema_1
+            - $ref: external_schema_2
+
+ptr: /internal/mirror/ext

--- a/validator/test/test_validator.py
+++ b/validator/test/test_validator.py
@@ -34,3 +34,9 @@ class TestGetSchemaInfoFromPointer:
 
     def test_one_of_multiple(self):
         self.do_fxt_test("one_of_multiple.yml")
+
+    def test_external_ref_obj(self):
+        self.do_fxt_test("external_ref_obj.yml")
+
+    def test_external_ref_obj_oneof(self):
+        self.do_fxt_test("external_ref_obj_oneof.yml")


### PR DESCRIPTION
## Overview 
This PR allows having external refs as object attributes besides array items. 

## Why this change/example: 

Without these changes, the following example fails the validation in the integration manifest when it tries to validate the `shard` reference. `$ref` is only allowed as an array item, not as an object attribute. 

```yaml 
# Integration schema 
- namespace:
    $ref: /services/app-interface/namespaces/app-interface-production-int.yml
  spec:
  [ ...] 
  sharding: # <-- external schema: integration-sharding-v1.yml
    strategy: per-openshift-cluster
    shardSpecOverrides: 
    - shard:
        $ref: /openshift/appsrep05ue1/cluster.yml
      imageRef: bla
      # ... 
```

Check the tests for other examples. 

