### PR TITLE
Upgrade PyYAML to ~= 6.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         "Click~=8.1",
         "jsonschema~=3.2",
-        "PyYAML~=5.3",
+        "PyYAML~=6.0.1",
         "requests~=2.24",
         "jsonpath-ng~=1.5",
     ],


### PR DESCRIPTION
There are two main reasons for this:

* PyYAML 5.4.1 is two years old
* PyYAML 5.4.1 issues with Python 3.11 and Cython (see https://github.com/yaml/pyyaml/issues/601)

part of APPSRE-8002