### PR TITLE
Add validate_bundle method

### DIFF
--- a/validator/validator.py
+++ b/validator/validator.py
@@ -466,6 +466,7 @@ def validate_bundle(bundle: Bundle) -> list[dict]:
         + results_graphql_schemas
     )
 
+
 @click.command()
 @click.option("--only-errors", is_flag=True, help="Print only errors")
 @click.argument("bundlefile", type=click.File("rb"))

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -411,12 +411,7 @@ def get_schema_info_from_pointer(schema, ptr, schemas_bundle) -> list[dict]:
     return [info]
 
 
-@click.command()
-@click.option("--only-errors", is_flag=True, help="Print only errors")
-@click.argument("bundlefile", type=click.File("rb"))
-def main(only_errors, bundlefile: IO):
-    bundle = load_bundle(bundlefile)
-
+def validate_bundle(bundle: Bundle) -> list[dict]:
     # Validate schemas
     results_schemas = [
         validate_schema(bundle.schemas, filename, schema_data).dump()
@@ -462,8 +457,7 @@ def main(only_errors, bundlefile: IO):
         else []
     )
 
-    # Calculate errors
-    results = (
+    return (
         results_schemas
         + results_files
         + results_unique_fields
@@ -471,6 +465,16 @@ def main(only_errors, bundlefile: IO):
         + results_refs
         + results_graphql_schemas
     )
+
+@click.command()
+@click.option("--only-errors", is_flag=True, help="Print only errors")
+@click.argument("bundlefile", type=click.File("rb"))
+def main(only_errors, bundlefile: IO):
+    bundle = load_bundle(bundlefile)
+
+    results = validate_bundle(bundle)
+
+    # Calculate errors
     errors = list(filter(lambda x: x["result"]["status"] == "ERROR", results))
 
     # Output


### PR DESCRIPTION
Add a method validate_bundle, that takes the validation setps and groups them together. By that I can reuse this code outside of the validator in qontract-reconcile. The goal is to be able to validate generated datafiles from templates withouth the need to actually generate the templates. This will be achieved by using the validator integration, with the templateTests.

[APPSRE-8796](https://issues.redhat.com/browse/APPSRE-8796)



required for: https://github.com/app-sre/qontract-reconcile/pull/4081